### PR TITLE
Add extras share to runners

### DIFF
--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -7,15 +7,16 @@ from kubernetes import client  # type: ignore[import]
 from jobcreator.utils import logger, load_kubernetes_config
 
 
-def _setup_archive_pv(job_name: str) -> str:
+def _setup_archive_pv(job_name: str, secret_namespace: str) -> str:
     """
     Sets up the archive PV using the loaded kubeconfig as a destination
     :param job_name: str, the name of the job needing an archive
+    :param secret_namespace: str, the namespace of the secret for mounting
     :return: str, the name of the archive PV
     """
     pv_name = f"{job_name}-archive-pv-smb"
     metadata = client.V1ObjectMeta(name=pv_name, annotations={"pv.kubernetes.io/provisioned-by": "smb.csi.k8s.io"})
-    secret_ref = client.V1SecretReference(name="archive-creds", namespace="fia")
+    secret_ref = client.V1SecretReference(name="archive-creds", namespace=secret_namespace)
     csi = client.V1CSIPersistentVolumeSource(
         driver="smb.csi.k8s.io",
         read_only=True,
@@ -55,6 +56,62 @@ def _setup_archive_pvc(job_name: str, job_namespace: str) -> str:
         api_version="v1", kind="PersistentVolumeClaim", metadata=metadata, spec=spec
     )
     client.CoreV1Api().create_namespaced_persistent_volume_claim(namespace=job_namespace, body=archive_pvc)
+    return pvc_name
+
+
+def _setup_extras_pv(job_name: str, secret_namespace: str, manila_share_id: str, manila_share_access_id: str) -> str:
+    """
+    Setups up the extras PV using the loaded kubeconfig as destination
+    :param job_name: str, the name of the job the PV is for
+    :param manila_share_id: The id of the manila share to mount for extras
+    :param manila_share_access_id: the id of the access rule for the manila share that provides access to the
+    manila share
+    :param secret_namespace: the namespace where the manila-creds secret is.
+    :return: str, the name of the PV
+    """
+    pv_name = f"{job_name}-extras-pv"
+    metadata = client.V1ObjectMeta(name=pv_name, labels={"name": pv_name})
+    secret_ref = client.V1SecretReference(name="manila-creds", namespace=secret_namespace)
+    csi = client.V1CSIPersistentVolumeSource(
+        driver="cephfs.manila.csi.openstack.org",
+        read_only=True,
+        volume_handle=pv_name,
+        volume_attributes={"shareID": manila_share_id, "shareAccessID": manila_share_access_id},
+        node_stage_secret_ref=secret_ref,
+        node_publish_secret_ref=secret_ref
+    )
+    spec = client.V1PersistentVolumeSpec(
+        capacity={"storage": "1000Gi"},
+        access_modes=["ReadOnlyMany"],
+        csi=csi,
+    )
+    archive_pv = client.V1PersistentVolume(api_version="v1", kind="PersistentVolume", metadata=metadata, spec=spec)
+    client.CoreV1Api().create_persistent_volume(archive_pv)
+    return pv_name
+
+
+def _setup_extras_pvc(job_name: str, job_namespace: str, pv_name: str) -> str:
+    """
+    Sets up the extras Manila PVC using the loaded kubeconfig as a destination
+    :param job_name: str, the name of the job that the PVC is made for
+    :param job_namespace: str, the namespace that the job is in
+    :param pv_name: str, the name of the PV the PVC is being made for
+    :return: str, the name of the PVC
+    """
+    pvc_name = f"{job_name}-extras-pvc"
+    metadata = client.V1ObjectMeta(name=pvc_name)
+    resources = client.V1ResourceRequirements(requests={"storage": "1000Gi"})
+    match_expression = client.V1LabelSelectorRequirement(key="name", operator="In", values=[pv_name])
+    selector = client.V1LabelSelector(match_expressions=[match_expression])
+    spec = client.V1PersistentVolumeClaimSpec(
+        access_modes=["ReadOnlyMany"],
+        resources=resources,
+        selector=selector,
+        storage_class_name="",
+    )
+    extras_pvc = client.V1PersistentVolumeClaim(api_version="v1", kind="PersistentVolumeClaim",
+                                                metadata=metadata, spec=spec)
+    client.CoreV1Api().create_namespaced_persistent_volume_claim(namespace=job_namespace, body=extras_pvc)
     return pvc_name
 
 
@@ -153,6 +210,8 @@ class JobCreator:
         db_username: str,
         db_password: str,
         runner_sha: str,
+        manila_share_id: str,
+        manila_share_access_id: str,
     ) -> None:
         """
         Takes the meta_data from the message and uses that dictionary for generating the deployment of the pod.
@@ -171,6 +230,9 @@ class JobCreator:
         :param db_password: the database password to use to connect
         :param runner_sha: The sha used for defining what version the runner is
         the containers have permission to use the directories required for outputting data.
+        :param manila_share_id: The id of the manila share to mount for extras
+        :param manila_share_access_id: the id of the access rule for the manila share that provides access to the
+        manila share
         :return: None
         """
         logger.info("Creating PV and PVC for: %s", job_name)
@@ -178,18 +240,24 @@ class JobCreator:
         pv_names = []
         pvc_names = []
         # Setup PVs
-        pv_names.append(_setup_archive_pv(job_name=job_name))
+        pv_names.append(_setup_archive_pv(job_name=job_name, secret_namespace=job_namespace))
         if not self.dev_mode:
             pv_names.append(
                 _setup_ceph_pv(
                     job_name, ceph_creds_k8s_secret_name, ceph_creds_k8s_namespace, cluster_id, fs_name, ceph_mount_path
                 )
             )
+        extras_pv_name = _setup_extras_pv(job_name=job_name, secret_namespace=job_namespace,
+                                          manila_share_id=manila_share_id,
+                                          manila_share_access_id=manila_share_access_id)
+        pv_names.append(extras_pv_name)
 
         # Setup PVCs
         pvc_names.append(_setup_archive_pvc(job_name=job_name, job_namespace=job_namespace))
         if not self.dev_mode:
             pvc_names.append(_setup_ceph_pvc(job_name=job_name, job_namespace=job_namespace))
+        pvc_names.append(_setup_extras_pvc(job_name=job_name, job_namespace=job_namespace,
+                                           pv_name=extras_pv_name))
 
         # Create the Job
         logger.info("Spawning job: %s", job_name)
@@ -200,6 +268,7 @@ class JobCreator:
             volume_mounts=[
                 client.V1VolumeMount(name="archive-mount", mount_path="/archive"),
                 client.V1VolumeMount(name="ceph-mount", mount_path="/output"),
+                client.V1VolumeMount(name="extras-mount", mount_path="/extras"),
             ],
         )
 
@@ -242,6 +311,12 @@ class JobCreator:
                     ),
                 ),
                 ceph_volume,
+                client.V1Volume(
+                    name="extras-mount",
+                    persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=f"{job_name}-extras-pvc", read_only=True
+                    )
+                )
             ],
         )
 

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -110,6 +110,8 @@ def process_message(message: Dict[str, Any]) -> None:  # pylint: disable=too-man
             db_password=DB_PASSWORD,
             max_time_to_complete_job=MAX_TIME_TO_COMPLETE,
             runner_sha=MANTID_SHA,
+            manila_share_id=MANILA_SHARE_ID,
+            manila_share_access_id=MANILA_SHARE_ACCESS_ID,
         )
     except Exception as exception:  # pylint: disable=broad-exception-caught
         logger.exception(exception)

--- a/job_creator/jobcreator/main.py
+++ b/job_creator/jobcreator/main.py
@@ -50,6 +50,9 @@ CEPH_CREDS_SECRET_NAMESPACE = os.environ.get("CEPH_CREDS_SECRET_NAMESPACE", "fia
 CLUSTER_ID = os.environ.get("CLUSTER_ID", "ba68226a-672f-4ba5-97bc-22840318b2ec")
 FS_NAME = os.environ.get("FS_NAME", "deneb")
 
+MANILA_SHARE_ID = os.environ.get("MANILA_SHARE_ID", "05b75577-a8fb-4c87-a3f3-6a07012e80bc")
+MANILA_SHARE_ACCESS_ID = os.environ.get("MANILA_SHARE_ACCESS_ID", "8045701a-0c3e-486b-a89b-4fd741d04f69")
+
 MAX_TIME_TO_COMPLETE = int(os.environ.get("MAX_TIME_TO_COMPLETE", 60 * 60 * 6))
 
 

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -5,7 +5,8 @@ import unittest
 from unittest import mock
 from unittest.mock import call
 
-from jobcreator.job_creator import JobCreator, _setup_archive_pv, _setup_archive_pvc, _setup_ceph_pv, _setup_ceph_pvc
+from jobcreator.job_creator import (JobCreator, _setup_archive_pv, _setup_archive_pvc, _setup_ceph_pv, _setup_ceph_pvc,
+                                    _setup_extras_pv, _setup_extras_pvc)
 
 
 class JobCreatorTest(unittest.TestCase):
@@ -13,8 +14,9 @@ class JobCreatorTest(unittest.TestCase):
     def test_setup_archive_pv(self, client):
         job_name = str(mock.MagicMock())
         pv_name = f"{job_name}-archive-pv-smb"
+        secret_namespace = mock.MagicMock()
 
-        self.assertEqual(_setup_archive_pv(job_name), pv_name)
+        self.assertEqual(_setup_archive_pv(job_name, secret_namespace), pv_name)
 
         client.CoreV1Api.return_value.create_persistent_volume.assert_called_once_with(
             client.V1PersistentVolume.return_value
@@ -42,7 +44,7 @@ class JobCreatorTest(unittest.TestCase):
             volume_attributes={"source": "//isisdatar55.isis.cclrc.ac.uk/inst$/"},
             node_stage_secret_ref=client.V1SecretReference.return_value,
         )
-        client.V1SecretReference.assert_called_once_with(name="archive-creds", namespace="fia")
+        client.V1SecretReference.assert_called_once_with(name="archive-creds", namespace=secret_namespace)
 
     @mock.patch("jobcreator.job_creator.client")
     def test_setup_archive_pvc(self, client):
@@ -69,6 +71,73 @@ class JobCreatorTest(unittest.TestCase):
         client.CoreV1Api.return_value.create_namespaced_persistent_volume_claim.assert_called_once_with(
             namespace=job_namespace, body=client.V1PersistentVolumeClaim.return_value
         )
+
+    @mock.patch("jobcreator.job_creator.client")
+    def test_setup_extras_pvc(self, client):
+        job_name = str(mock.MagicMock())
+        job_namespace = str(mock.MagicMock())
+        pvc_name = f"{job_name}-extras-pvc"
+        pv_name = mock.MagicMock()
+
+        self.assertEqual(_setup_extras_pvc(job_name, job_namespace, pv_name), pvc_name)
+
+        client.V1ObjectMeta.assert_called_once_with(name=pvc_name)
+        client.V1ResourceRequirements(requests={"storage": "1000Gi"})
+        client.V1LabelSelectorRequirement.assert_called_once_with(key="name", operator="In", values=[pv_name])
+        client.V1LabelSelector.assert_called_once_with(
+            match_expressions=[client.V1LabelSelectorRequirement.return_value])
+        client.V1PersistentVolumeClaimSpec.assert_called_once_with(
+            access_modes=["ReadOnlyMany"],
+            resources=client.V1ResourceRequirements.return_value,
+            selector=client.V1LabelSelector.return_value,
+            storage_class_name="",
+        )
+        client.V1PersistentVolumeClaim.assert_called_once_with(
+            api_version="v1",
+            kind="PersistentVolumeClaim",
+            metadata=client.V1ObjectMeta.return_value,
+            spec=client.V1PersistentVolumeClaimSpec.return_value,
+        )
+        client.CoreV1Api.return_value.create_namespaced_persistent_volume_claim.assert_called_once_with(
+            namespace=job_namespace, body=client.V1PersistentVolumeClaim.return_value
+        )
+
+    @mock.patch("jobcreator.job_creator.client")
+    def test_setup_extras_pv(self, client):
+        job_name = str(mock.MagicMock())
+        pv_name = f"{job_name}-extras-pv"
+        secret_namespace = mock.MagicMock()
+        manila_share_id = mock.MagicMock()
+        manila_share_access_id = mock.MagicMock()
+
+        self.assertEqual(_setup_extras_pv(job_name, secret_namespace, manila_share_id, manila_share_access_id), pv_name)
+
+        client.CoreV1Api.return_value.create_persistent_volume.assert_called_once_with(
+            client.V1PersistentVolume.return_value
+        )
+        client.V1PersistentVolume.assert_called_once_with(
+            api_version="v1",
+            kind="PersistentVolume",
+            metadata=client.V1ObjectMeta.return_value,
+            spec=client.V1PersistentVolumeSpec.return_value,
+        )
+        client.V1ObjectMeta.assert_called_once_with(
+            name=pv_name, labels={"name": pv_name}
+        )
+        client.V1PersistentVolumeSpec.assert_called_once_with(
+            capacity={"storage": "1000Gi"},
+            access_modes=["ReadOnlyMany"],
+            csi=client.V1CSIPersistentVolumeSource.return_value,
+        )
+        client.V1CSIPersistentVolumeSource.assert_called_once_with(
+            driver="cephfs.manila.csi.openstack.org",
+            read_only=True,
+            volume_handle=pv_name,
+            volume_attributes={"shareID": manila_share_id, "shareAccessID": manila_share_access_id},
+            node_stage_secret_ref=client.V1SecretReference.return_value,
+            node_publish_secret_ref=client.V1SecretReference.return_value
+        )
+        client.V1SecretReference.assert_called_once_with(name="manila-creds", namespace=secret_namespace)
 
     @mock.patch("jobcreator.job_creator.client")
     def test_setup_ceph_pv(self, client):
@@ -153,6 +222,8 @@ class JobCreatorTest(unittest.TestCase):
 
         mock_load_kubernetes_config.assert_called_once()
 
+    @mock.patch("jobcreator.job_creator._setup_extras_pv")
+    @mock.patch("jobcreator.job_creator._setup_extras_pvc")
     @mock.patch("jobcreator.job_creator._setup_archive_pv")
     @mock.patch("jobcreator.job_creator._setup_archive_pvc")
     @mock.patch("jobcreator.job_creator._setup_ceph_pv")
@@ -160,7 +231,8 @@ class JobCreatorTest(unittest.TestCase):
     @mock.patch("jobcreator.job_creator.load_kubernetes_config")
     @mock.patch("jobcreator.job_creator.client")
     def test_jobcreator_spawn_job_dev_mode_false(
-        self, client, _, setup_ceph_pvc, setup_ceph_pv, setup_archive_pvc, setup_archive_pv
+        self, client, _, setup_ceph_pvc, setup_ceph_pv, setup_archive_pvc, setup_archive_pv,
+            setup_extras_pvc, setup_extras_pv
     ):
         job_name = mock.MagicMock()
         script = mock.MagicMock()
@@ -178,6 +250,8 @@ class JobCreatorTest(unittest.TestCase):
         runner_sha = mock.MagicMock()
         watcher_sha = mock.MagicMock()
         job_creator = JobCreator(watcher_sha, False)
+        manila_share_id = mock.MagicMock()
+        manila_share_access_id = mock.MagicMock()
 
         job_creator.spawn_job(
             job_name,
@@ -194,6 +268,8 @@ class JobCreatorTest(unittest.TestCase):
             db_username,
             db_password,
             runner_sha,
+            manila_share_id,
+            manila_share_access_id,
         )
 
         self.assertEqual(
@@ -212,8 +288,8 @@ class JobCreatorTest(unittest.TestCase):
             name=job_name,
             annotations={
                 "reduction-id": str(reduction_id),
-                "pvs": str([setup_archive_pv.return_value, setup_ceph_pv.return_value]),
-                "pvcs": str([setup_archive_pvc.return_value, setup_ceph_pvc.return_value]),
+                "pvs": str([setup_archive_pv.return_value, setup_ceph_pv.return_value, setup_extras_pv.return_value]),
+                "pvcs": str([setup_archive_pvc.return_value, setup_ceph_pvc.return_value, setup_extras_pvc.return_value]),
                 "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
             },
         )
@@ -226,7 +302,7 @@ class JobCreatorTest(unittest.TestCase):
             containers=[client.V1Container.return_value, client.V1Container.return_value],
             restart_policy="Never",
             tolerations=[client.V1Toleration.return_value],
-            volumes=[client.V1Volume.return_value, client.V1Volume.return_value],
+            volumes=[client.V1Volume.return_value, client.V1Volume.return_value, client.V1Volume.return_value],
         )
         self.assertIn(
             call(name="ceph-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value),
@@ -236,14 +312,24 @@ class JobCreatorTest(unittest.TestCase):
             call(claim_name=f"{job_name}-ceph-pvc", read_only=False),
             client.V1PersistentVolumeClaimVolumeSource.call_args_list,
         )
-        client.V1Volume.assert_called_with(
-            name="archive-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value
+        self.assertIn(
+            call(name="extras-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value),
+            client.V1Volume.call_args_list
         )
-        client.V1PersistentVolumeClaimVolumeSource.assert_called_with(
-            claim_name=f"{job_name}-archive-pvc", read_only=True
+        self.assertIn(
+            call(claim_name=f"{job_name}-extras-pvc", read_only=True),
+            client.V1PersistentVolumeClaimVolumeSource.call_args_list
         )
-        self.assertEqual(client.V1Volume.call_count, 2)
-        self.assertEqual(client.V1PersistentVolumeClaimVolumeSource.call_count, 2)
+        self.assertIn(
+            call(name="archive-mount", persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource.return_value),
+            client.V1Volume.call_args_list
+        )
+        self.assertIn(
+            call(claim_name=f"{job_name}-archive-pvc", read_only=True),
+            client.V1PersistentVolumeClaimVolumeSource.call_args_list
+        )
+        self.assertEqual(client.V1Volume.call_count, 3)
+        self.assertEqual(client.V1PersistentVolumeClaimVolumeSource.call_count, 3)
         self.assertIn(
             call(
                 name="job-watcher",
@@ -268,6 +354,7 @@ class JobCreatorTest(unittest.TestCase):
                 volume_mounts=[
                     client.V1VolumeMount(name="archive-mount", mount_path="/archive"),
                     client.V1VolumeMount(name="ceph-mount", mount_path="/output"),
+                    client.V1VolumeMount(name="extras-mount", mount_path="/extras")
                 ],
             ),
             client.V1Container.call_args_list,
@@ -279,6 +366,8 @@ class JobCreatorTest(unittest.TestCase):
         )
         setup_ceph_pvc.assert_called_once_with(job_name=job_name, job_namespace=job_namespace)
 
+    @mock.patch("jobcreator.job_creator._setup_extras_pv")
+    @mock.patch("jobcreator.job_creator._setup_extras_pvc")
     @mock.patch("jobcreator.job_creator._setup_archive_pv")
     @mock.patch("jobcreator.job_creator._setup_archive_pvc")
     @mock.patch("jobcreator.job_creator._setup_ceph_pv")
@@ -286,7 +375,8 @@ class JobCreatorTest(unittest.TestCase):
     @mock.patch("jobcreator.job_creator.load_kubernetes_config")
     @mock.patch("jobcreator.job_creator.client")
     def test_jobcreator_spawn_job_dev_mode_true(
-        self, client, _, setup_ceph_pvc, setup_ceph_pv, setup_archive_pvc, setup_archive_pv
+        self, client, _, setup_ceph_pvc, setup_ceph_pv, setup_archive_pvc, setup_archive_pv,
+            setup_extras_pvc, setup_extras_pv
     ):
         job_name = mock.MagicMock()
         script = mock.MagicMock()
@@ -303,6 +393,8 @@ class JobCreatorTest(unittest.TestCase):
         db_password = mock.MagicMock()
         runner_sha = mock.MagicMock()
         job_creator = JobCreator(mock.MagicMock(), True)
+        manila_share_id = mock.MagicMock()
+        manila_share_access_id = mock.MagicMock()
 
         job_creator.spawn_job(
             job_name,
@@ -319,14 +411,16 @@ class JobCreatorTest(unittest.TestCase):
             db_username,
             db_password,
             runner_sha,
+            manila_share_id,
+            manila_share_access_id,
         )
 
         client.V1ObjectMeta.assert_called_once_with(
             name=job_name,
             annotations={
                 "reduction-id": str(reduction_id),
-                "pvs": str([setup_archive_pv.return_value]),
-                "pvcs": str([setup_archive_pvc.return_value]),
+                "pvs": str([setup_archive_pv.return_value, setup_extras_pv.return_value]),
+                "pvcs": str([setup_archive_pvc.return_value, setup_extras_pvc.return_value]),
                 "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
             },
         )
@@ -335,6 +429,8 @@ class JobCreatorTest(unittest.TestCase):
             client.V1Volume.call_args_list,
         )
         client.V1EmptyDirVolumeSource.assert_called_once_with(size_limit="10000Mi")
+        self.assertEqual(client.V1Volume.call_count, 3)
+        self.assertEqual(client.V1PersistentVolumeClaimVolumeSource.call_count, 2)
 
         setup_ceph_pv.assert_not_called()
         setup_ceph_pvc.assert_not_called()


### PR DESCRIPTION
Needed for https://github.com/orgs/fiaisis/projects/4/views/1?pane=issue&itemId=45908534 as part of some work to enable this work

## Description
Runners now have a Manila CEPHFS share mounted at `/extras` that is read only, it's purpose is for calibration files, or other similar files that can't be easily generated for reductions.