### PR TITLE
Fix bug with ceph mounting

### DIFF
--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -147,7 +147,7 @@ def _setup_ceph_pv(
             "mounter": "fuse",
             "fsName": fs_name,
             "staticVolume": "true",
-            "rootPath": "/isis/instrument" + ceph_mount_path,
+            "rootPath": ceph_mount_path,
         },
     )
     spec = client.V1PersistentVolumeSpec(

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -191,7 +191,7 @@ def test_setup_ceph_pv(client):
             "mounter": "fuse",
             "fsName": fs_name,
             "staticVolume": "true",
-            "rootPath": "/isis/instrument" + ceph_mount_path,
+            "rootPath": ceph_mount_path,
         },
     )
     client.V1SecretReference.assert_called_once_with(


### PR DESCRIPTION
Closes None, noticed in production

## Description
Presently we are adding "/isis/instrument" to the front of the ceph mount path two times, this should only have been once.