### PR TITLE
Add pod label to enable anti-affinity

### DIFF
--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -380,7 +380,7 @@ class JobCreator:
                 "pvs": str(pv_names),
                 "pvcs": str(pvc_names),
                 "kubectl.kubernetes.io/default-container": main_container.name,
-            }
+            },
         )
 
         job = client.V1Job(

--- a/job_creator/jobcreator/job_creator.py
+++ b/job_creator/jobcreator/job_creator.py
@@ -361,7 +361,11 @@ class JobCreator:
             ],
         )
 
-        template = client.V1PodTemplateSpec(spec=pod_spec)
+        pod_metadata = client.V1ObjectMeta(
+            labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
+        )
+
+        template = client.V1PodTemplateSpec(spec=pod_spec, metadata=pod_metadata)
 
         spec = client.V1JobSpec(
             template=template,
@@ -369,21 +373,20 @@ class JobCreator:
             ttl_seconds_after_finished=21600,  # 6 hours
         )
 
-        metadata = client.V1ObjectMeta(
+        job_metadata = client.V1ObjectMeta(
             name=job_name,
             annotations={
                 "reduction-id": str(reduction_id),
                 "pvs": str(pv_names),
                 "pvcs": str(pvc_names),
                 "kubectl.kubernetes.io/default-container": main_container.name,
-            },
-            labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
+            }
         )
 
         job = client.V1Job(
             api_version="batch/v1",
             kind="Job",
-            metadata=metadata,
+            metadata=job_metadata,
             spec=spec,
         )
         client.BatchV1Api().create_namespaced_job(namespace=job_namespace, body=job)

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -299,24 +299,23 @@ def test_jobcreator_spawn_job_dev_mode_false(
         metadata=client.V1ObjectMeta.return_value,
         spec=client.V1JobSpec.return_value,
     )
-    client.V1ObjectMeta.assert_called_once_with(
-        name=job_name,
-        annotations={
+    assert call(name=job_name, annotations={
             "reduction-id": str(reduction_id),
             "pvs": str([setup_archive_pv.return_value, setup_ceph_pv.return_value, setup_extras_pv.return_value]),
             "pvcs": str(
                 [setup_archive_pvc.return_value, setup_ceph_pvc.return_value, setup_extras_pvc.return_value],
             ),
             "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
-        },
-        labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
-    )
+        }) in client.V1ObjectMeta.call_args_list
+    assert call(labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"}) in client.V1ObjectMeta.call_args_list
+    assert client.V1ObjectMeta.call_count == 2  # noqa: PLR2004
     client.V1JobSpec.assert_called_once_with(
         template=client.V1PodTemplateSpec.return_value,
         backoff_limit=0,
         ttl_seconds_after_finished=21600,
     )
-    client.V1PodTemplateSpec.assert_called_once_with(spec=client.V1PodSpec.return_value)
+    client.V1PodTemplateSpec.assert_called_once_with(spec=client.V1PodSpec.return_value,
+                                                     metadata=client.V1ObjectMeta.return_value)
     client.V1LabelSelector.assert_called_once_with(
         match_labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
     )
@@ -461,16 +460,6 @@ def test_jobcreator_spawn_job_dev_mode_true(
         manila_share_access_id,
     )
 
-    client.V1ObjectMeta.assert_called_once_with(
-        name=job_name,
-        annotations={
-            "reduction-id": str(reduction_id),
-            "pvs": str([setup_archive_pv.return_value, setup_extras_pv.return_value]),
-            "pvcs": str([setup_archive_pvc.return_value, setup_extras_pvc.return_value]),
-            "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
-        },
-        labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
-    )
     assert (
         call(name="ceph-mount", empty_dir=client.V1EmptyDirVolumeSource.return_value) in client.V1Volume.call_args_list
     )

--- a/job_creator/test/test_job_creator.py
+++ b/job_creator/test/test_job_creator.py
@@ -299,23 +299,32 @@ def test_jobcreator_spawn_job_dev_mode_false(
         metadata=client.V1ObjectMeta.return_value,
         spec=client.V1JobSpec.return_value,
     )
-    assert call(name=job_name, annotations={
-            "reduction-id": str(reduction_id),
-            "pvs": str([setup_archive_pv.return_value, setup_ceph_pv.return_value, setup_extras_pv.return_value]),
-            "pvcs": str(
-                [setup_archive_pvc.return_value, setup_ceph_pvc.return_value, setup_extras_pvc.return_value],
-            ),
-            "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
-        }) in client.V1ObjectMeta.call_args_list
-    assert call(labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"}) in client.V1ObjectMeta.call_args_list
+    assert (
+        call(
+            name=job_name,
+            annotations={
+                "reduction-id": str(reduction_id),
+                "pvs": str([setup_archive_pv.return_value, setup_ceph_pv.return_value, setup_extras_pv.return_value]),
+                "pvcs": str(
+                    [setup_archive_pvc.return_value, setup_ceph_pvc.return_value, setup_extras_pvc.return_value],
+                ),
+                "kubectl.kubernetes.io/default-container": client.V1Container.return_value.name,
+            },
+        )
+        in client.V1ObjectMeta.call_args_list
+    )
+    assert (
+        call(labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"}) in client.V1ObjectMeta.call_args_list
+    )
     assert client.V1ObjectMeta.call_count == 2  # noqa: PLR2004
     client.V1JobSpec.assert_called_once_with(
         template=client.V1PodTemplateSpec.return_value,
         backoff_limit=0,
         ttl_seconds_after_finished=21600,
     )
-    client.V1PodTemplateSpec.assert_called_once_with(spec=client.V1PodSpec.return_value,
-                                                     metadata=client.V1ObjectMeta.return_value)
+    client.V1PodTemplateSpec.assert_called_once_with(
+        spec=client.V1PodSpec.return_value, metadata=client.V1ObjectMeta.return_value
+    )
     client.V1LabelSelector.assert_called_once_with(
         match_labels={"reduce.isis.cclrc.ac.uk/job-source": "automated-reduction"},
     )


### PR DESCRIPTION
Closes None, noticed in production and a trivial fix.

## Description
Noticed that the anti-affinity wasn't working in prod after a quick investigation, the fix is trivial as the label was on the job instead of the pod.